### PR TITLE
Remove unnecessary comma

### DIFF
--- a/gtk-3.0/widgets/toolbar.css
+++ b/gtk-3.0/widgets/toolbar.css
@@ -79,7 +79,7 @@ GthEmbeddedDialog .button:active:focus {
 }
 
 .primary-toolbar .raised .button:active,
-.primary-toolbar .raised.button:active,
+.primary-toolbar .raised.button:active
 {
     transition: 200ms linear;
     border-radius: 0px;


### PR DESCRIPTION
Fixes error "expected a valid selector"

```
(utopic:21509): Gtk-WARNING **: Theme parsing error: toolbar.css:83:0: Expected a valid selector
```